### PR TITLE
Update Boost

### DIFF
--- a/.github/workflows/XmsMesher-CI.yaml
+++ b/.github/workflows/XmsMesher-CI.yaml
@@ -1,4 +1,4 @@
-name: XmsMesher-3.0
+name: XmsMesher-4.0
 
 on: [push, pull_request]
 
@@ -54,9 +54,9 @@ jobs:
     env:
       # Library Variables
       LIBRARY_NAME: xmsmesher
-      XMS_VERSION: 3.0.0
+      XMS_VERSION: 4.0.0
       # Conan Variables
-      CONAN_REFERENCE: xmsmesher/3.0.0
+      CONAN_REFERENCE: xmsmesher/4.0.0
       CONAN_ARCHS: x86_64
       CONAN_USERNAME: aquaveo
       CONAN_CHANNEL: testing
@@ -173,9 +173,9 @@ jobs:
     env:
       # Library Variables
       LIBRARY_NAME: xmsmesher
-      XMS_VERSION: 3.0.0
+      XMS_VERSION: 4.0.0
       # Conan Variables
-      CONAN_REFERENCE: xmsmesher/3.0.0
+      CONAN_REFERENCE: xmsmesher/4.0.0
       CONAN_ARCHS: x86_64
       CONAN_USERNAME: aquaveo
       CONAN_CHANNEL: testing
@@ -301,9 +301,9 @@ jobs:
     env:
       # Library Variables
       LIBRARY_NAME: xmsmesher
-      XMS_VERSION: 3.0.0
+      XMS_VERSION: 4.0.0
       # Conan Variables
-      CONAN_REFERENCE: xmsmesher/3.0.0
+      CONAN_REFERENCE: xmsmesher/4.0.0
       CONAN_ARCHS: x86_64
       CONAN_USERNAME: aquaveo
       CONAN_CHANNEL: testing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,11 +55,7 @@ if(WIN32)
         add_definitions(/Zc:wchar_t-)  # Treat wchar_t as typedef
     endif()
 
-    if(XMS_BUILD)
-        add_definitions(/D _WIN32_WINNT=0x0501)  # Windows XP and higher
-    else(NOT XMS_BUILD)
-        add_definitions(/D BOOST_ALL_NO_LIB)
-    endif()
+    add_definitions(/D BOOST_ALL_NO_LIB)
 endif()
 
 if(IS_PYTHON_BUILD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,7 @@ else() # If we are not using conda, we are using conan
 endif(IS_CONDA_BUILD)
 
 if(WIN32)
-    string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MT" USES_MT)
-    if(NOT USES_MT)
-        string(COMPARE EQUAL "${CONAN_SETTINGS_COMPILER_RUNTIME}" "MTd" USES_MT)
-    endif()
-
-    if(USES_MT)
+    if(USES_NATIVE_WCHAR_T)
         message("Treating wchar_t as a built-in type.")
         add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ else() # If we are not using conda, we are using conan
 endif(IS_CONDA_BUILD)
 
 if(WIN32)
-    if(USES_NATIVE_WCHAR_T)
+    if(USE_NATIVE_WCHAR_T)
         message("Treating wchar_t as a built-in type.")
         add_definitions(/Zc:wchar_t)  # Treat wchar_t as built-in type
     else()

--- a/_package/xms/mesher/__init__.py
+++ b/_package/xms/mesher/__init__.py
@@ -2,4 +2,4 @@
 from . import meshing  # NOQA: F401
 from .api.mesh import generate_mesh  # NOQA: F401
 
-__version__ = '3.0.2'
+__version__ = '4.0.0'

--- a/build.py
+++ b/build.py
@@ -67,4 +67,19 @@ if __name__ == "__main__":
         testing_updated_builds.append([settings, options, env_vars, build_requires])
     builder.builds = testing_updated_builds
 
+    wchar_updated_builds = []
+    for settings, options, env_vars, build_requires, reference in builder.items:
+        # wchar_t option
+        if settings['compiler'] == 'Visual Studio' and not options.get('xmsinterp:pybind', False):
+            wchar_options = dict(options)
+            wchar_options.update({'xmsinterp:wchar_t': 'typedef'})
+            wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])
+        elif settings['compiler'] == 'Visual Studio':
+            wchar_options = dict(options)
+            wchar_options.update({'xmsinterp:wchar_t': 'builtin'})
+            wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])
+        else:
+            wchar_updated_builds.append([settings, options, env_vars, build_requires])
+    builder.builds = wchar_updated_builds
+
     builder.run()

--- a/build.py
+++ b/build.py
@@ -70,13 +70,13 @@ if __name__ == "__main__":
     wchar_updated_builds = []
     for settings, options, env_vars, build_requires, reference in builder.items:
         # wchar_t option
-        if settings['compiler'] == 'Visual Studio' and not options.get('xmsinterp:pybind', False):
+        if settings['compiler'] == 'Visual Studio' and not options.get('xmsmesher:pybind', False):
             wchar_options = dict(options)
-            wchar_options.update({'xmsinterp:wchar_t': 'typedef'})
+            wchar_options.update({'xmsmesher:wchar_t': 'typedef'})
             wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])
         elif settings['compiler'] == 'Visual Studio':
             wchar_options = dict(options)
-            wchar_options.update({'xmsinterp:wchar_t': 'builtin'})
+            wchar_options.update({'xmsmesher:wchar_t': 'builtin'})
             wchar_updated_builds.append([settings, wchar_options, env_vars, build_requires])
         else:
             wchar_updated_builds.append([settings, options, env_vars, build_requires])

--- a/conanfile.py
+++ b/conanfile.py
@@ -60,6 +60,10 @@ class XmsinterpConan(ConanFile):
             self.options['xmsgrid'].wchar_t = self.options.wchar_t
             self.options['boost'].wchar_t = self.options.wchar_t
 
+    def config_options(self):
+        if self.settings.compiler != 'Visual Studio':
+            del self.options.wchar_t
+
     def requirements(self):
         """Requirements."""
         if self.settings.compiler == 'Visual Studio' and 'MD' in str(self.settings.compiler.runtime):

--- a/conanfile.py
+++ b/conanfile.py
@@ -89,7 +89,7 @@ class XmsinterpConan(ConanFile):
         cmake.definitions["XMS_TEST_PATH"] = "test_files"
         cmake.definitions["PYTHON_TARGET_VERSION"] = self.env.get("PYTHON_TARGET_VERSION", "3.6")
         if self.settings.compiler == 'Visual Studio':
-            cmake.definitions["USE_TYPEDEF_WCHAR_T"] = (self.options.wchar_t == 'typedef')
+            cmake.definitions["USE_NATIVE_WCHAR_T"] = (self.options.wchar_t == 'builtin')
         cmake.configure(source_folder=".")
         cmake.build()
         cmake.install()

--- a/conanfile.py
+++ b/conanfile.py
@@ -34,6 +34,14 @@ class XmsinterpConan(ConanFile):
         s_compiler = self.settings.compiler
         s_compiler_version = self.settings.compiler.version
 
+        if s_compiler == "apple-clang" and s_os == 'Linux':
+            raise ConanException("Clang on Linux is not supported.")
+
+        if s_compiler == "apple-clang" \
+                and s_os == 'Macos' \
+                and float(s_compiler_version.value) < 9.0:
+            raise ConanException("Clang > 9.0 is required for Mac.")
+
         self.options['xmscore'].xms = self.options.xms
         self.options['xmscore'].pybind = self.options.pybind
         self.options['xmscore'].testing = self.options.testing
@@ -45,14 +53,6 @@ class XmsinterpConan(ConanFile):
         self.options['xmsgrid'].xms = self.options.xms
         self.options['xmsgrid'].pybind = self.options.pybind
         self.options['xmsgrid'].testing = self.options.testing
-
-        if s_compiler == "apple-clang" and s_os == 'Linux':
-            raise ConanException("Clang on Linux is not supported.")
-
-        if s_compiler == "apple-clang" \
-                and s_os == 'Macos' \
-                and float(s_compiler_version.value) < 9.0:
-            raise ConanException("Clang > 9.0 is required for Mac.")
 
     def requirements(self):
         """Requirements."""

--- a/conanfile.py
+++ b/conanfile.py
@@ -54,7 +54,7 @@ class XmsinterpConan(ConanFile):
         self.options['xmsgrid'].pybind = self.options.pybind
         self.options['xmsgrid'].testing = self.options.testing
         
-        if s_compiler == 'Visual studio':
+        if s_compiler == 'Visual Studio':
             self.options['xmscore'].wchar_t = self.options.wchar_t
             self.options['xmsinterp'].wchar_t = self.options.wchar_t
             self.options['xmsgrid'].wchar_t = self.options.wchar_t

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,17 +45,20 @@ class XmsinterpConan(ConanFile):
         if s_compiler == 'Visual Studio' and self.options.wchar_t == 'typedef' and self.options.pybind:
             raise ConanException("wchar_t=typedef not supported with pybind=True")
 
-        self.options['xmscore'].xms = self.options.xms
         self.options['xmscore'].pybind = self.options.pybind
         self.options['xmscore'].testing = self.options.testing
 
-        self.options['xmsinterp'].xms = self.options.xms
         self.options['xmsinterp'].pybind = self.options.pybind
         self.options['xmsinterp'].testing = self.options.testing
 
-        self.options['xmsgrid'].xms = self.options.xms
         self.options['xmsgrid'].pybind = self.options.pybind
         self.options['xmsgrid'].testing = self.options.testing
+        
+        if s_compiler == 'Visual studio':
+            self.options['xmscore'].wchar_t = self.options.wchar_t
+            self.options['xmsinterp'].wchar_t = self.options.wchar_t
+            self.options['xmsgrid'].wchar_t = self.options.wchar_t
+            self.options['boost'].wchar_t = self.options.wchar_t
 
     def requirements(self):
         """Requirements."""

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,6 +88,8 @@ class XmsinterpConan(ConanFile):
         cmake.definitions["BUILD_TESTING"] = self.options.testing
         cmake.definitions["XMS_TEST_PATH"] = "test_files"
         cmake.definitions["PYTHON_TARGET_VERSION"] = self.env.get("PYTHON_TARGET_VERSION", "3.6")
+        if self.settings.compiler == 'Visual Studio':
+            cmake.definitions["USE_TYPEDEF_WCHAR_T"] = (self.options.wchar_t == 'typedef')
         cmake.configure(source_folder=".")
         cmake.build()
         cmake.install()

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,6 +42,9 @@ class XmsinterpConan(ConanFile):
                 and float(s_compiler_version.value) < 9.0:
             raise ConanException("Clang > 9.0 is required for Mac.")
 
+        if s_compiler == 'Visual Studio' and self.options.wchar_t == 'typedef' and self.options.pybind:
+            raise ConanException("wchar_t=typedef not supported with pybind=True")
+
         self.options['xmscore'].xms = self.options.xms
         self.options['xmscore'].pybind = self.options.pybind
         self.options['xmscore'].testing = self.options.testing

--- a/conanfile.py
+++ b/conanfile.py
@@ -66,22 +66,15 @@ class XmsinterpConan(ConanFile):
 
     def requirements(self):
         """Requirements."""
-        if self.settings.compiler == 'Visual Studio' and 'MD' in str(self.settings.compiler.runtime):
-            self.requires("boost/1.74.0@aquaveo/testing")  # Use legacy wchar_t setting for XMS.
-        else:
-            self.requires("boost/1.74.0@aquaveo/stable")
+        self.requires("boost/1.74.0.3@aquaveo/stable")
 
         # Pybind if not clang
         if not self.settings.compiler == "clang" and self.options.pybind:
             self.requires("pybind11/2.5.0@aquaveo/testing")
 
-        self.requires("xmscore/4.0.2@aquaveo/stable")
-        self.requires("xmsgrid/5.4.2@aquaveo/stable")
-        self.requires("xmsinterp/4.1.0@aquaveo/stable")
-        # zlib and bzip2 are required by boost. They used to get pulled automatically from conan-center, but something
-        # changed and we now need to explicitly list them as requirements using the new style notation.
-        self.requires('zlib/1.2.11')
-        self.requires('bzip2/1.0.8')
+        self.requires("xmscore/5.0.1@aquaveo/stable")
+        self.requires("xmsgrid/6.0.0@aquaveo/stable")
+        self.requires("xmsinterp/5.0.0@aquaveo/stable")
 
     def build(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,11 +11,15 @@ class XmsinterpConan(ConanFile):
     description = "Meshing library for XMS products"
     settings = "os", "compiler", "build_type", "arch"
     options = {
-        "xms": [True, False],
+        "wchar_t": ['builtin', 'typedef'],
         "pybind": [True, False],
         "testing": [True, False],
     }
-    default_options = "xms=False", "pybind=False", "testing=False"
+    default_options = {
+        'wchar_t': 'builtin',
+        'pybind': False,
+        'testing': False,
+    }
     generators = "cmake"
     build_requires = "cxxtest/4.4@aquaveo/stable"
     exports = "CMakeLists.txt", "LICENSE", "test_files/*"
@@ -71,9 +75,6 @@ class XmsinterpConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-
-        if self.settings.compiler == 'Visual Studio':
-            cmake.definitions["XMS_BUILD"] = self.options.xms
 
         # CXXTest doesn't play nice with PyBind. Also, it would be nice to not
         # have tests in release code. Thus, if we want to run tests, we will


### PR DESCRIPTION
- Removed the `xms` option from `conanfile.py`. This was an internal option that was no longer used.
- Added `wchar_t` option to conanfile.py to control Visual Studio's `/Zc:wchar_t` flag.
- Switch to a new Boost package that doesn't have any external dependencies.
- Update to xmscore 5.0.1, xmsgrid 6.0.0, and xmsinterp to 5.0.0.