### PR TITLE
Bump xmscore to 7.0.6, xmsgrid to 9.0.7, xmsinterp to 7.0.6

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -13,9 +13,9 @@ endif()
 """
 
 xms_dependencies = [
-    { name = "xmscore", version = "7.0.4" },
-    { name = "xmsgrid", version = "9.0.5" },
-    { name = "xmsinterp", version = "7.0.4" }
+    { name = "xmscore", version = "7.0.6" },
+    { name = "xmsgrid", version = "9.0.7" },
+    { name = "xmsinterp", version = "7.0.6" }
 ]
 
 extra_export_sources = [


### PR DESCRIPTION
## Summary
- Update xms dependencies to latest releases (xmsconan 2.6.0 cascade)

## Test plan
- CI passes with updated dependency versions