### PR TITLE
Bump xms deps; regen CI from xmsconan 2.12.2 with py3.10 + py3.13 builds

### DIFF
--- a/.github/workflows/XmsMesher-CI.yaml
+++ b/.github/workflows/XmsMesher-CI.yaml
@@ -82,6 +82,7 @@ jobs:
       # Python Variables
       PYTHON_TARGET_VERSION: ${{ matrix.python-version }}
       RELEASE_PYTHON: 'False'
+      CTEST_PARALLEL_LEVEL: '8'
 
     steps:
       # Get Correct Version of Xcode
@@ -95,16 +96,16 @@ jobs:
       - name: Checkout Source
         uses: actions/checkout@v2
       # Setup Python
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       # Install Python Dependencies
       - name: Install Python Dependencies
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.6.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login --remove-conancenter
@@ -138,8 +139,15 @@ jobs:
         run: xmsconan_gen --version ${{ env.XMS_VERSION }} build.toml
       # Build the Conan Package
       - name: Build the Conan Packages
-        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse"
+        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse --artifacts-dir test_artifacts"
         shell: bash
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ env.MATRIX_NAME }}
+          path: test_artifacts/
+          if-no-files-found: ignore
+        if: always()
       # Repair wheel (Release only)
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform macos
@@ -221,6 +229,7 @@ jobs:
       # Python Variables
       PYTHON_TARGET_VERSION: '3.13'
       RELEASE_PYTHON: 'False'
+      CTEST_PARALLEL_LEVEL: '8'
 
     steps:
       # Checkout Sources
@@ -230,7 +239,7 @@ jobs:
       - name: Install Python Dependencies
         run: |
           pip install conan devpi-client wheel
-          pip install xmsconan>=2.6.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Conan
       - name: Setup Conan
         run: xmsconan_conan_setup --remote-url ${{ env.CONAN_REMOTE_URL }} --login
@@ -264,8 +273,15 @@ jobs:
         run: xmsconan_gen --version ${{ env.XMS_VERSION }} build.toml
       # Build the Conan Package
       - name: Build the Conan Packages
-        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse"
+        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse --artifacts-dir test_artifacts"
         shell: bash
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ env.MATRIX_NAME }}
+          path: test_artifacts/
+          if-no-files-found: ignore
+        if: always()
       # Repair wheel (Release only)
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform linux
@@ -322,12 +338,12 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-2022]
-        python-version: ['3.13']
+        python-version: ["3.10", "3.13"]
         compiler-version: [17]
         build_type: [Release, Debug]
 
     env:
-      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}
+      MATRIX_NAME: ${{ matrix.platform }}-VS${{ matrix.compiler-version }}-${{ matrix.build_type }}-py${{ matrix.python-version }}
       # Library Variables
       LIBRARY_NAME: xmsmesher
       XMS_VERSION: '0.0.0'
@@ -347,16 +363,17 @@ jobs:
       # Python Variables
       PYTHON_TARGET_VERSION: ${{ matrix.python-version }}
       RELEASE_PYTHON: 'False'
+      CTEST_PARALLEL_LEVEL: '8'
 
     steps:
       # Checkout Sources
       - name: Checkout Source
         uses: actions/checkout@v2
       # Setup Python
-      - name: Set up Python 3.13
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       # Setup Dev Command Prompt env for MSVC
       - name: Setup MSVC env
         uses: ilammy/msvc-dev-cmd@v1
@@ -367,7 +384,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install conan devpi-client wheel
-          python -m pip install xmsconan>=2.6.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
+          python -m pip install xmsconan>=2.12.2 -i https://public.aquapi.aquaveo.com/aquaveo/dev/+simple
       # Setup Visual Studio
       - name: Setup Visual Studio
         uses: microsoft/setup-msbuild@v2
@@ -404,8 +421,15 @@ jobs:
         run: xmsconan_gen --version ${{ env.XMS_VERSION }} build.toml
       # Build the Conan Package
       - name: Build the Conan Packages
-        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse"
+        run: "python build.py --filter=\"{\\\"build_type\\\": \\\"${{ matrix.build_type }}\\\"}\" --wheel-dir wheelhouse --artifacts-dir test_artifacts"
         shell: cmd
+      - name: Upload test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-artifacts-${{ env.MATRIX_NAME }}
+          path: test_artifacts/
+          if-no-files-found: ignore
+        if: always()
       # Repair wheel (Release only)
       - name: Repair wheel
         run: xmsconan_wheel_repair --wheel-dir wheelhouse --platform windows
@@ -414,7 +438,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ runner.os }}
+          name: wheel-${{ runner.os }}-py${{ matrix.python-version }}
           path: wheelhouse/*.whl
         if: matrix.build_type == 'Release'
       # Upload wheel to Aquapi

--- a/build.toml
+++ b/build.toml
@@ -13,9 +13,9 @@ endif()
 """
 
 xms_dependencies = [
-    { name = "xmscore", version = "7.0.7" },
-    { name = "xmsgrid", version = "9.0.8" },
-    { name = "xmsinterp", version = "7.0.7" }
+    { name = "xmscore", version = "7.0.8" },
+    { name = "xmsgrid", version = "9.0.9" },
+    { name = "xmsinterp", version = "7.0.8" }
 ]
 
 extra_export_sources = [
@@ -102,3 +102,6 @@ pybind_sources = [
 pybind_headers = [
   "xmsmesher/python/meshing/meshing_py.h"
 ]
+
+[ci]
+python_versions = ["3.10", "3.13"]


### PR DESCRIPTION
## Summary
- Bumped xmscore 7.0.7→7.0.8, xmsgrid 9.0.8→9.0.9, xmsinterp 7.0.7→7.0.8 in `build.toml`.
- Added `[ci] python_versions = ["3.10", "3.13"]` and regenerated the CI yaml from xmsconan 2.12.2 (also bumps the `xmsconan>=` pin to 2.12.2 and picks up template improvements: test-artifacts upload, `CTEST_PARALLEL_LEVEL`, `--artifacts-dir`, py-suffixed wheel artifact name).
- Note: the upstream xmsconan 2.12.2 GitHub template only fans the **Windows** matrix across Python versions; Mac and Linux jobs remain on 3.13 in the template, so wheels for py3.10 are produced on Windows only.

## Test plan
- [ ] CI passes on the new branch (Mac, Linux, Windows × py3.10 + py3.13).
- [ ] Verify Windows produces both py3.10 and py3.13 wheel artifacts.